### PR TITLE
fix: make every deploy module importable on its own

### DIFF
--- a/deploy/__main__.py
+++ b/deploy/__main__.py
@@ -1,13 +1,8 @@
 import argparse
-import os
-import sys
 
-# 'deploy' ディレクトリをPythonのモジュール検索パスに追加
-sys.path.append(os.path.dirname(__file__))
-
-from handlers.deploy_to_android import deploy_to_android
-from handlers.deploy_to_linux import deploy_to_linux
-from handlers.deploy_to_mac import deploy_to_mac
+from deploy.handlers.deploy_to_android import deploy_to_android
+from deploy.handlers.deploy_to_linux import deploy_to_linux
+from deploy.handlers.deploy_to_mac import deploy_to_mac
 
 
 def main():

--- a/deploy/shared/setup_claude.py
+++ b/deploy/shared/setup_claude.py
@@ -1,8 +1,7 @@
 import os
 
-from shared.create_symlink_safely import create_symlink_safely
-
-from .paths import DOTFILES_ROOT, HOME_DIR
+from deploy.shared.create_symlink_safely import create_symlink_safely
+from deploy.shared.paths import DOTFILES_ROOT, HOME_DIR
 
 
 def setup_claude():


### PR DESCRIPTION
## Summary

`deploy/shared/setup_claude.py` could not be imported on its own. Neither could `deploy_to_mac`, which imports it. The deploy command itself worked, which is why this went unnoticed.

```
>>> import deploy.shared.setup_claude
ModuleNotFoundError: No module named 'shared'
```

## What was wrong

Two files reached for names that only resolve when the `deploy` directory itself is on `sys.path`:

```python
# deploy/shared/setup_claude.py
from shared.create_symlink_safely import create_symlink_safely

# deploy/__main__.py
from handlers.deploy_to_android import deploy_to_android
```

`__main__.py` arranged for exactly that, before importing anything:

```python
sys.path.append(os.path.dirname(__file__))
```

So the command ran, and the modules were broken in any other context — a test being the obvious one.

`setup_claude.py` was the sole exception among its siblings, and inconsistent with itself as well: a bare absolute import on one line, a relative one on the next, where thirteen other files under `deploy/` spell both `deploy.shared.<module>`.

## The sys.path detour was never needed

`python3 -m deploy` places the current directory at `sys.path[0]`. That is how the `deploy` package is found at all, so `from deploy.handlers.…` resolves through the same entry. Appending the `deploy` directory on top of that only added a second, redundant search path.

It also bought nothing it appeared to. Running from outside the repository fails identically with and without it, because the package must be found before any line of `__main__.py` executes — the hack cannot run early enough to help. What it did accomplish was keeping `deploy/` importable as a top level, which is what allowed `from shared.…` to work at runtime and stay hidden.

## Verification

Checked in a fresh `git clone` with no caches, run under `env -i` with the system python3, against a build of this branch and one without it:

| Invocation | Before | After |
|---|---|---|
| `cd dotfiles && python3 -m deploy --help` | works | works |
| `cd dotfiles && python3 -m deploy {android,linux,mac} --help` | works | works |
| `python3 deploy/__main__.py --help` | fails | fails |
| `python3 -m deploy` from outside the repository | fails | fails |
| `python3 <repo>/deploy/__main__.py` from elsewhere | fails | fails |

Identical in every case: what worked still works, what did not still does not. Also confirmed unaffected by a polluted `PYTHONPATH`.

Beyond that: all 16 modules now import individually, where two failed before, and ruff is clean.

## For reviewers

`deploy/CODING_CONVENTIONS.md` states that `sys.path` must not be manipulated, and the entry point was the one place doing it. That document is due to be removed during the upcoming test work, so it is deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)