### PR TITLE
docs: add git conventions and a rule to ask instead of guessing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,3 +4,12 @@ Comments and in-source documentation MUST explain only why.
 The only exception: mark test sections with "Arrange", "Act", and "Assert" comments.
 
 In tests, only the parts that interact with external systems MAY be replaced with fakes.
+
+## Git
+
+Commit messages and pull requests MUST be written in plain English.
+Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.
+
+## When in Doubt
+
+Ask instead of guessing. A question costs far less than work built on a wrong assumption.


### PR DESCRIPTION
Two rules that were being pasted into prompts by hand, written down so they apply every session instead of only when remembered.

## `## Git`

Commit messages and pull requests must be plain English, branch names must follow Conventional Branch, and commit messages must follow Conventional Commits. These are the two things that varied most across sessions: how the prose is written, and how branches and commits are named.

## `## When in Doubt`

`Ask instead of guessing. A question costs far less than work built on a wrong assumption.`

The heading is about doubt rather than questions, and that is the whole point of it. A heading like "If You Have Questions" presupposes the question is already formed; the failure it needs to catch happens earlier, at the moment an unclear point gets quietly filled in with a guess. The second sentence carries the "feel free to ask" part of the original prompt, restated as a cost comparison, because that is what actually lowers the threshold for interrupting.

## Notes for the reviewer

Wording follows the file's existing register. The two new rules in `## Git` use MUST because they are mechanically checkable and there is no good reason to deviate. `## When in Doubt` deliberately drops RFC 2119 keywords: it states the behaviour and the reason for it, which reads better than grading an imperative that has judgement in it.

`## When in Doubt` is a prepositional phrase among noun-phrase headings. That is intentional -- it marks the section as a situational rule rather than a domain standard.

This file is symlinked to `~/.claude/CLAUDE.md` from a different clone (`~/Documents/GitHub/dotfiles`), so the global config picks this up only after that clone pulls.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)