### PR TITLE
docs: prohibit comments by default and require concise writing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,6 @@
-## Coding Standards
+## Rules
+
+### Comments
 
 Comments and in-source documentation MUST NOT be written.
 The only exceptions:
@@ -6,9 +8,11 @@ The only exceptions:
 - a comment that explains why (which MUST be as concise as possible)
 - "Arrange", "Act", and "Assert" comments that mark test sections
 
+### Tests
+
 In tests, only the parts that interact with external systems MAY be replaced with fakes.
 
-## Git
+### Git
 
 Commit messages and pull requests MUST be written in plain English and be as concise as possible.
 Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,13 +1,16 @@
 ## Coding Standards
 
-Comments and in-source documentation MUST explain only why.
-The only exception: mark test sections with "Arrange", "Act", and "Assert" comments.
+Comments and in-source documentation MUST NOT be written.
+The only exceptions:
+
+- a comment that explains why (which MUST be as concise as possible)
+- "Arrange", "Act", and "Assert" comments that mark test sections
 
 In tests, only the parts that interact with external systems MAY be replaced with fakes.
 
 ## Git
 
-Commit messages and pull requests MUST be written in plain English.
+Commit messages and pull requests MUST be written in plain English and be as concise as possible.
 Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.
 
 ## When in Doubt


### PR DESCRIPTION
Comments and in-source documentation are now prohibited, with two exceptions listed as bullets: a comment that explains why, and the "Arrange" / "Act" / "Assert" markers in tests. The previous "MUST explain only why" read as permission to comment whenever a why was at hand.

The why it still allows must be as concise as possible, and commit messages and pull requests now carry the same requirement.

`## Coding Standards` becomes `## Rules` with one subheading per topic (Comments, Tests, Git), so each rule has a visible boundary and Git sits under a parent it belongs to.

`~/.claude/CLAUDE.md` is a symlink to this file, so the change takes effect everywhere on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)