### PR TITLE
docs: explain why why-comments must be concise

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 Comments and in-source documentation MUST NOT be written.
 The only exceptions:
 
-- a comment that explains why (which MUST be as concise as possible)
+- a comment that explains why (which MUST be as concise as possible, so it is less likely to go stale)
 - "Arrange", "Act", and "Assert" comments that mark test sections
 
 ### Tests


### PR DESCRIPTION
## What

The conciseness rule for why-comments now states its reason: `so it is less likely to go stale`.

## Why

The rule told me to keep why-comments short without saying what that buys. The point is that comments drift out of sync with the code over time, and a shorter comment has less surface that can go stale. Stating the reason makes the rule easier to apply to borderline cases.

## Notes for reviewers

- `stale` is the established term for "no longer matches the code" (`stale data`, `stale cache`), so it is used here instead of spelling out the divergence.
- The wording says `less likely to` rather than `prevents`: brevity reduces how much can drift, it does not rule drift out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)