### PR TITLE
docs: add a PR hard wrap rule and the reason for plain English

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,7 +14,8 @@ In tests, only the parts that interact with external systems MAY be replaced wit
 
 ### Git
 
-Commit messages and pull requests MUST be written in plain English and be as concise as possible.
+Commit messages and pull requests MUST be written in plain English and be as concise as possible, so that as many people around the world as possible can read them.
+Pull request descriptions MUST NOT be hard wrapped.
 Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.
 
 ## When in Doubt


### PR DESCRIPTION
## What

Two additions to the Git rules in `.claude/CLAUDE.md`: the plain English rule now states its purpose, and pull request descriptions are now exempt from hard wrapping.

## Why

The plain English rule said what to do without saying who it is for. It is for readers around the world, many of whom do not read English as a first language, so the rule now says so.

Hard wrapping was never settled either way for pull requests. GitHub renders every line break in an issue, pull request, or discussion body as written, unlike a `.md` file in a repository. Wrapping therefore fixes the text to a width the reader did not choose, and a narrow window wraps it a second time. The rule now settles it.

## Notes for reviewers

- The rule states no reason. It is recorded here and in the commit message instead.
- The new line sits directly after the other rule about what to write, before the naming conventions, so that related rules read together.
- The 72 character convention still applies to commit message bodies, where Git never reflows the text. Leaving that undocumented is deliberate: it is already the practice here, and Conventional Commits says nothing about it either way.
- This description is not hard wrapped, following the rule it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
