### PR TITLE
docs: allow why-comments only where they are needed

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,10 +2,10 @@
 
 ### Comments
 
-Comments and in-source documentation MUST NOT be written.
+Comments and embedded documentation MUST NOT be written in any file.
 The only exceptions:
 
-- a comment that explains why (which MUST be as concise as possible, so it is less likely to go stale)
+- a comment that explains why, only where the reason cannot be understood without it, and as concise as possible, so that it is less likely to go stale or to say something untrue
 - "Arrange", "Act", and "Assert" comments that mark test sections
 
 ### Tests
@@ -17,6 +17,7 @@ In tests, only the parts that interact with external systems MAY be replaced wit
 Commit messages and pull requests MUST be written in plain English and be as concise as possible, so that as many people around the world as possible can read them.
 Pull request descriptions MUST NOT be hard wrapped.
 Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.
+Before a branch is created, the latest changes on the remote default branch MUST be pulled in.
 
 ## When in Doubt
 


### PR DESCRIPTION
The comment rules said "in-source documentation", which reads as if they only covered source code. They cover every file, including workflows and configuration, so the wording now says so.

A why-comment is now allowed only where the reason cannot be understood without it. Every comment can drift away from what it describes, so the fewer and the shorter they are, the less room there is for one of them to say something untrue.

The Git section also gains a rule to pull in the latest changes on the remote default branch before a branch is created, so work does not start from a stale base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)