### PR TITLE
chore(deps): group minor and patch updates and merge them automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ version: 2
 # between a release and the pull request short, and the limit of one keeps that
 # frequency from filling the list: a superseded pull request is replaced rather
 # than accumulating beside the others.
+#
+# Minor and patch updates are grouped so that auto-merge lands them in one pull
+# request, leaving a major update on its own to be read. The group cannot span the
+# ecosystems below: Dependabot filters by update type only within one.
 updates:
   # uv is its own ecosystem here, separate from pip. It reads pyproject.toml and
   # uv.lock, which between them are the only place a tool version is pinned.
@@ -12,6 +16,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
 
   # Covers the `uses:` references in .github/workflows. setup-uv has to name an
   # exact version, because Astral publishes no floating tag for its newest major,
@@ -21,6 +29,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
 
   # The base image the docker-diff-guard action falls back to. It is pinned in a
   # Dockerfile nothing builds, because this is the only kind of file Dependabot
@@ -30,3 +42,7 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+name: Dependabot auto-merge
+
+# pull_request_target is what makes the App credentials reachable: a workflow that
+# Dependabot triggers through pull_request sees Dependabot's own secrets instead of
+# the repository's. Nothing from the pull request is checked out or executed here,
+# which is what keeps that trigger safe.
+on: pull_request_target
+
+# Every permission is dropped because the App token, not this one, does the work.
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
+      - uses: dependabot/fetch-metadata@v3
+        id: metadata
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      # A grouped pull request reports the highest update type it carries, so the
+      # minor and patch group matches and anything holding a major does not.
+      - name: merge once the required checks pass
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "${PR_URL}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What

Dependabot now groups its minor and patch updates into one pull request per ecosystem, and a new workflow turns on auto-merge for those pull requests so that they squash into `main` once the required checks pass. A major update is left alone.

## Why

Every update arrived as its own pull request and every one of them was merged by hand, including the patch bumps that exist only to keep a pinned version current. Grouping and auto-merge take that work away, while a major update, the one that can change how something behaves, still waits to be read.

## Notes for reviewers

- The group is written once per ecosystem because Dependabot filters by update type only within one. A single group covering uv, GitHub Actions and Docker at the same time is not expressible.
- The workflow runs on `pull_request_target`, because a workflow that Dependabot triggers through `pull_request` sees Dependabot's secrets rather than the repository's and so cannot reach the App's private key. Nothing from the pull request is checked out or executed, which is what makes that trigger safe here.
- `permissions: {}` drops the workflow token, since the GitHub App token does the work.
- The merge condition accepts only `semver-minor` and `semver-patch`. A grouped pull request reports the highest update type it carries, so a group holding a major never matches.
- `pull_request_target` reads the workflow from the base branch, so this will not run against this pull request. It starts working once it is on `main`.
- `open-pull-requests-limit` stays at 1. A group counts as one pull request, so an open major update still holds the next group back, the same way it held individual updates back before.
- The repository side is already in place: auto-merge is allowed, and `AUTO_MERGE_APP_ID` and `AUTO_MERGE_APP_PRIVATE_KEY` are registered as Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)