### PR TITLE
docs: require attribution in commits and pull requests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ In tests, only the parts that interact with external systems MAY be replaced wit
 
 Commit messages and pull requests MUST be written in plain English and be as concise as possible, so that as many people around the world as possible can read them.
 Pull request descriptions MUST NOT be hard wrapped.
+Commit messages and pull request descriptions MUST carry the attribution of the AI agent that helped write the change.
 Branch names MUST follow Conventional Branch, and commit messages MUST follow Conventional Commits.
 Before a branch is created, the latest changes on the remote default branch MUST be pulled in.
 


### PR DESCRIPTION
Commits and pull requests in this repository already carry the attribution of the AI agent that helped write them, but no rule said they must. The Git section now says so, placed next to the other rules about what a commit message and a pull request description contain, so the branch rules stay together.

The rule asks for "the attribution" rather than a `Co-authored-by` trailer. The trailer key and the pull request line are both Claude Code settings (`attribution.commit` and `attribution.pr`, with the older `includeCoAuthoredBy` now deprecated), so naming either one in the rule would go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)