### PR TITLE
Say when a fake may stand in and how far a test case must reach

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,7 +10,9 @@ The only exceptions:
 
 ### Tests
 
-In tests, only the parts that interact with external systems MAY be replaced with fakes.
+A test case MUST run from as near the entry point as it can to as near the outside as it can.
+A part MAY be replaced with a fake only where the test cannot have the real thing.
+Where it can, a fake is allowed only when the real thing would let the assertion pass where the specification does not, and another test case states what that part does.
 
 ### Git
 


### PR DESCRIPTION
The Tests rule allowed a fake only where a part interacts with an external system. That was a stand-in for what was meant — a fake must not leave a specification unstated anywhere — and it broke on the first part that is neither outside nor safe to route an assertion through.

## What broke it

A test case stating that a CD rip keeps the samples three reads of the disc agreed on. The rip writes a FLAC, so the case held that file against a file it encoded itself from the samples that should have won. That says the two encodings match, which is the same as saying the samples match only where the encoder is faithful — a property of the very code the assertion travels through. An encoder that wrote the same thing whatever it was handed would have kept the case green.

A decoder narrows the hole rather than closing it: where an encoder maps two runs of samples to the same bytes, decoding recovers only one of them. The only observation that closes it is one taken before the value enters the encoder. Under the old rule that was forbidden, because a FLAC encoder is not an external system.

## What is written down now

```
A test case MUST run from as near the entry point as it can to as near the outside as it can.
A part MAY be replaced with a fake only where the test cannot have the real thing.
Where it can, a fake is allowed only when the real thing would let the assertion pass where the specification does not, and another test case states what that part does.
```

The first line was true all along and had never been written down. It is what makes the second paragraph an exception rather than an alternative: breadth is the default, and precision beats breadth only where they conflict.

The second half of the exception is what keeps this from becoming a way to test less. What the fake replaces has to be stated by another test case, so the cover moves rather than goes — and to use the exception you must already have written that other case. It cannot lower the total, only relocate it.

## How it decides the case that prompted it

Faking the encoder is allowed: routing through it lets the assertion pass where the specification does not, and what FLAC makes of samples is stated by a job that rips a disc and holds the file against tools from the other side of the format — the reference implementation, `metaflac`, and Apple's decoder, none of which a test case in the same language can ask.

In the neighbouring case, which states that a rip fails when ten reads never agree three times, the real encoder stays. Nothing there passes that should not: a rip that failed writes no file, and an empty folder says so plainly.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
