### PR TITLE
docs: require comments to be written in plain English

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,6 +8,8 @@ The only exceptions:
 - a comment that explains why, only where the reason cannot be understood without it, and as concise as possible, so that it is less likely to go stale or to say something untrue
 - "Arrange", "Act", and "Assert" comments that mark test sections
 
+A comment MUST be written in plain English, so that as many people around the world as possible can read it.
+
 ### Tests
 
 A test case MUST run from as near the entry point as it can to as near the outside as it can.

--- a/deploy/shared/setup_git.py
+++ b/deploy/shared/setup_git.py
@@ -7,7 +7,7 @@ from deploy.shared.paths import HOME_DIR
 def setup_git():
     print("--- Setting up common Git configurations ---")
 
-    # このファイルが存在しなかった場合、`git config --global`で設定したときに~/.config/git/configに書き込まれてしまう
+    # Without this file, `git config --global` writes to ~/.config/git/config instead.
     gitconfig_path = os.path.join(HOME_DIR, ".gitconfig")
     if not os.path.exists(gitconfig_path):
         print(f"  Creating empty {gitconfig_path}")


### PR DESCRIPTION
The Git section already asks for plain English in commit messages and pull requests, so that as many people around the world as possible can read them. Nothing said the same about the few comments this repository still allows, so a comment could be written in any language and stay within the rules.

The rule now covers comments as well. The one comment that was left in the repository had been written in Japanese, so it is in English now. Nothing else in the code changes.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
